### PR TITLE
fix(eslint-config): prevent from updating Prettier to minor version (only patches)

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -24,7 +24,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-prettier": "^4.0.0",
-    "prettier": "^2.4.1",
+    "prettier": "~2.4.1",
     "prettier-eslint-cli": "^5.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5484,7 +5484,7 @@ prettier@^1.7.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
-prettier@^2.4.1:
+prettier@~2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==


### PR DESCRIPTION
Because moving from minor version of Prettier to another may bring some formatting changes, this PR ensures to only update to patch versions.

According to the [documentation](https://github.com/npm/node-semver#caret-ranges-123-025-004) about the usage of carets on semver's versions, `^1.2.3` implies installing versions from `1.2.3` to `2.0.0` (not-included). But `~1.2.3` implies installing versions from `1.2.3` to `1.3.0` (not-included).