### PR TITLE
feat(vue): update rule error level denomination

### DIFF
--- a/packages/eslint-config-vue/index.js
+++ b/packages/eslint-config-vue/index.js
@@ -9,7 +9,7 @@ module.exports = {
   rules: {
     'no-param-reassign': ['error', { props: true, ignorePropertyModificationsFor: ['state'] }],
     'import/prefer-default-export': 'off',
-    'vue/max-attributes-per-line': [2, { singleline: 10 }],
+    'vue/max-attributes-per-line': ['error', { singleline: 10 }],
     'vue/html-closing-bracket-newline': ['error', { multiline: 'always' }],
     'vue/html-closing-bracket-spacing': ['error', { selfClosingTag: 'always' }],
   },


### PR DESCRIPTION
This minor improvement improves the readability of a rule error level.
I suggest at the same time we always write error levels plainly spelled out. That means with `off`, `warn`, `error` instead of `0`, `1`, `2`.
From ESLint official documentation:
> "off" or 0 - turn the rule off
"warn" or 1 - turn the rule on as a warning (doesn't affect exit code)
"error" or 2 - turn the rule on as an error (exit code is 1 when triggered)
(https://eslint.org/docs/user-guide/configuring/rules#configuring-rules)